### PR TITLE
Add support for double press actions in Aqara H2 EU switch blueprints

### DIFF
--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-aqara-h2-eu-1-switch.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-aqara-h2-eu-1-switch.yaml
@@ -21,3 +21,7 @@ buttons:
         conditions:
           - key: payload
             value: single_down
+      - title: press 2x
+        conditions:
+          - key: payload
+            value: double_down

--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-aqara-h2-eu-2-switch.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-aqara-h2-eu-2-switch.yaml
@@ -30,6 +30,10 @@ buttons:
         conditions:
           - key: payload
             value: single_left_down
+      - title: press 2x
+        conditions:
+          - key: payload
+            value: double_left_down
   - x: 104
     y: 104
     width: 81
@@ -39,3 +43,7 @@ buttons:
         conditions:
           - key: payload
             value: single_right_down
+      - title: press 2x
+        conditions:
+          - key: payload
+            value: double_right_down


### PR DESCRIPTION
Adds double press action support to the Zigbee2MQTT Aqara H2 EU switch blueprints (1-switch and 2-switch variants).

- `zigbee2mqtt-aqara-h2-eu-1-switch.yaml`: +4 lines
- `zigbee2mqtt-aqara-h2-eu-2-switch.yaml`: +8 lines