### PR TITLE
Add hold action to Aqara H2 EU 1-switch

### DIFF
--- a/custom_components/switch_manager/blueprints/zigbee2mqtt-aqara-h2-eu-1-switch.yaml
+++ b/custom_components/switch_manager/blueprints/zigbee2mqtt-aqara-h2-eu-1-switch.yaml
@@ -25,3 +25,11 @@ buttons:
         conditions:
           - key: payload
             value: double_down
+      - title: hold
+        conditions:
+          - key: payload
+            value: hold_down
+      - title: hold (released) 
+        conditions:
+          - key: payload
+            value: release_down


### PR DESCRIPTION
## Blueprint Checklist

- [x] You viewed the README and conformed to the [naming conventions](https://github.com/macpit/Home-Assistant-Switch-Manager#title-naming-convention)
- [x] You ordered the actions as stated in the README [action order](https://github.com/macpit/Home-Assistant-Switch-Manager#order-convention)
- [x] All filenames are lowercase and uses '-' for spaces and **not** '_' while using {service-name}-{switch-name-or-type}.yaml format
- [x] There are no missing buttons or actions
- [x] Your integration/service is running on the latest version
- [x] You have tested your blueprints and made sure each button and action works

#### Zigbee2MQTT

- [x] (**older devices**) You have ensured legacy is off/false for the device in the Z2M devices Settings (specific) page and that your actions matches those with legacy off?
