### PR TITLE
fix: close .identifier-ref.hint rule in identifier dialog styles — v5.2.1

### DIFF
--- a/custom_components/switch_manager/assets/switch_manager_panel.js
+++ b/custom_components/switch_manager/assets/switch_manager_panel.js
@@ -1217,6 +1217,7 @@ function t(t,e,i,s){var o,r=arguments.length,n=r<3?e:null===s?s=Object.getOwnPro
     }
     .identifier-ref.hint {
       margin-top: 8px;
+    }
     .error {
       margin-top: 8px;
       font-size: 0.9em;

--- a/custom_components/switch_manager/manifest.json
+++ b/custom_components/switch_manager/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/macpit/Home-Assistant-Switch-Manager/issues",
   "requirements": [],
-  "version": "5.2.0"
+  "version": "5.2.1"
 }

--- a/frontend/src/dialogs/identifier-auto-discovery.ts
+++ b/frontend/src/dialogs/identifier-auto-discovery.ts
@@ -335,6 +335,7 @@ export class SwitchManagerDialogIdentifierAutoDiscovery extends LitElement {
     }
     .identifier-ref.hint {
       margin-top: 8px;
+    }
     .error {
       margin-top: 8px;
       font-size: 0.9em;


### PR DESCRIPTION
Hotfix for v5.2.0.

When rebasing #74 onto #70 the conflict resolution in the identifier dialog styles dropped the closing brace of the `.identifier-ref.hint` rule. Every rule after it (`.error`, `.discovery`, `.list-item`, `.spinner`, ...) was parsed as a nested rule and never applied: no spinner, no highlight on the selected device, error text not red, discovery hint unstyled.

Found while testing v5.2.0 on the dev instance (HA 2026.9.0); verified after the fix: spinner visible, error red, first discovered device auto-filled and highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mw6uPemDEzSRMuKde1mEno
