### PR TITLE
feat: Zigbee2MQTT /action blueprints also listen on the device state topic (#77) — v5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ buttons:
 
 MQTT is handled differently to events and the incoming data is that of a payload... If a payload is not json formatted then it will be passed in as the key `payload` containing the string. The payload itself is what the conditions will check against. Included in the data is topic and topic_basename as this can be useful for condtions where a topic is listened via `#` or `+`.
 
-To help discover a switch when trying to discover from GUI then use a format for the topic in `mqtt_topic_format` that will scope down to the best possibility. For zigbee2mqtt this is generally `zigbee2mqtt/+/action`. The `+` is a wild card saying to match a single level (so anything between the forward slash `/`). For more information visit [here](https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices/). Sharing blueprints should be set to the default topic of the integration and not one that you have changed to. 
+To help discover a switch when trying to discover from GUI then use a format for the topic in `mqtt_topic_format` that will scope down to the best possibility. For zigbee2mqtt this is generally `zigbee2mqtt/+/action`. Blueprints with that format also receive the `action` key from the device's state topic `zigbee2mqtt/<device>` as `payload` (see [troubleshooting](#a-zigbee2mqtt-switch-is-never-discovered--does-nothing)), so they work whether or not Zigbee2MQTT's Home Assistant integration republishes to `/action`. The `+` is a wild card saying to match a single level (so anything between the forward slash `/`). For more information visit [here](https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices/). Sharing blueprints should be set to the default topic of the integration and not one that you have changed to. 
 
 If you want a condition on a payload that isn't json formatted then you would do as follows:
 ```yaml
@@ -500,15 +500,11 @@ You only see the mismatch error when a blueprint *dropped* buttons or actions, b
 
 #### A Zigbee2MQTT switch is never discovered / does nothing
 
-Most Zigbee2MQTT blueprints listen on `zigbee2mqtt/<device>/action`. That topic is not published by Zigbee2MQTT itself — it is republished by its **Home Assistant integration**, so it only exists when in Zigbee2MQTT:
+Most Zigbee2MQTT blueprints are written for `zigbee2mqtt/<device>/action`. That topic is not published by Zigbee2MQTT itself — it is republished by its **Home Assistant integration**, so it only exists when in Zigbee2MQTT the Home Assistant integration is **enabled** (`homeassistant.enabled: true`) and `advanced.output` is `json` (the default). The `legacy_action_sensor` option is unrelated.
 
-* the Home Assistant integration is **enabled** (`homeassistant.enabled: true`), and
-* `advanced.output` is `json` (the default — with `attribute` the integration refuses to start), and
-* the device is a supported one, not defined as a custom/unknown device.
+Since v5.3.0 this no longer matters for the switch itself: for `/action` blueprints Switch Manager also listens on the device's state topic `zigbee2mqtt/<device>` and uses the `action` key of its JSON payload (`{"action": "1_single", ...}`) as if it had arrived on `/action`. When Zigbee2MQTT publishes both, the second copy of a press is dropped, and retained state messages are ignored so a restart never replays the last press. The identifier of such a switch stays `zigbee2mqtt/<device>/action`, and auto discovery finds the device either way.
 
-You can check with any MQTT client (or the Zigbee2MQTT frontend) whether pressing the button publishes anything on `zigbee2mqtt/<device>/action`. If the device only publishes its state on `zigbee2mqtt/<device>`, none of the `/action` blueprints can ever match.
-
-The `legacy_action_sensor` option is unrelated to this topic even though toggling it has been reported to help — toggling it restarts Zigbee2MQTT, which is the more likely reason.
+If a switch still does nothing, check with any MQTT client (or the Zigbee2MQTT frontend) that pressing the button publishes on `zigbee2mqtt/<device>` (or `.../action`) at all, and that the topic matches the identifier of the switch, including the base topic (see [Zigbee2MQTT base topic](#zigbee2mqtt-base-topic--multiple-instances)).
 
 #### The panel looks unchanged after an update
 

--- a/custom_components/switch_manager/manifest.json
+++ b/custom_components/switch_manager/manifest.json
@@ -19,5 +19,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/macpit/Home-Assistant-Switch-Manager/issues",
   "requirements": [],
-  "version": "5.2.2"
+  "version": "5.3.0"
 }

--- a/custom_components/switch_manager/models.py
+++ b/custom_components/switch_manager/models.py
@@ -1,5 +1,6 @@
 import time
 import re
+import json
 import copy
 import asyncio
 from .const import DOMAIN, LOGGER, LOOP_MAX_SECONDS, LOOP_INTERVAL_DEFAULT, ZIGBEE2MQTT_DEFAULT_BASE_TOPIC
@@ -223,11 +224,69 @@ def replace_mqtt_base_topic( topic_format: str, base_topic: str ) -> str:
     _, _, rest = topic_format.partition('/')
     return f"{base_topic.strip('/')}/{rest}" if rest else base_topic.strip('/')
 
+# Zigbee2MQTT only republishes a button press to '<device>/action' when its Home
+# Assistant integration is enabled (and 'advanced.output' is json). The press is
+# always part of the JSON on the state topic '<device>' though, so blueprints
+# written for the '/action' topic also listen there and treat the 'action' key
+# as if it had arrived on '/action'. When Zigbee2MQTT publishes both, the second
+# copy of the same press is dropped (#77).
+ZIGBEE2MQTT_ACTION_SUFFIX = '/action'
+ZIGBEE2MQTT_DUPLICATE_WINDOW = 1.0  # seconds between the state and the /action copy
+
+def uses_zigbee2mqtt_action_topic( blueprint ) -> bool:
+    return bool(
+        blueprint.is_zigbee2mqtt
+        and blueprint.mqtt_topic_format.endswith( ZIGBEE2MQTT_ACTION_SUFFIX )
+    )
+
+def action_from_zigbee2mqtt_state( message: ReceiveMessage ):
+    """Return the 'action' of a Zigbee2MQTT state message, or None."""
+    if message.retain:
+        # A retained state would replay the last press whenever we (re)subscribe.
+        return None
+    try:
+        data = json.loads( message.payload )
+    except (ValueError, TypeError):
+        return None
+    if not isinstance( data, dict ):
+        return None
+    action = data.get( 'action' )
+    if not isinstance( action, str ) or not action:
+        return None
+    return action
+
 async def create_event_listeners( hass: HomeAssistant, blueprint, mqtt_topic, _callback ):
+    action_topics = blueprint.is_mqtt and uses_zigbee2mqtt_action_topic( blueprint )
+    # (topic, payload) -> (source, monotonic time) of the last press, to drop the
+    # copy that arrives on the other topic within the duplicate window.
+    recent_presses = {}
+
+    def _dispatch( data, source ):
+        if action_topics:
+            now = time.monotonic()
+            for key in [ k for k, v in recent_presses.items() if now - v[1] >= ZIGBEE2MQTT_DUPLICATE_WINDOW ]:
+                del recent_presses[key]
+            key = ( data.get('topic'), data.get('payload') )
+            previous = recent_presses.get( key )
+            if previous and previous[0] != source:
+                del recent_presses[key]
+                return
+            recent_presses[key] = ( source, now )
+        _callback( data, Context() )
+
     @callback
     def _handleMQTT( message: ReceiveMessage ):
-        data = format_mqtt_message(message)
-        _callback( data.copy(), Context() )
+        if action_topics and not message.topic.endswith( ZIGBEE2MQTT_ACTION_SUFFIX ):
+            action = action_from_zigbee2mqtt_state( message )
+            if action is None:
+                return
+            _dispatch( {
+                'payload': action,
+                'topic': f"{message.topic}{ZIGBEE2MQTT_ACTION_SUFFIX}",
+                'topic_basename': 'action'
+            }, 'state' )
+            return
+        _dispatch( format_mqtt_message(message).copy(), 'action' )
     
     @callback
     def _handleEvent( event ):
@@ -247,6 +306,12 @@ async def create_event_listeners( hass: HomeAssistant, blueprint, mqtt_topic, _c
     elif blueprint.is_mqtt:
         try:
             listeners.append( await mqtt_subscribe(hass, mqtt_topic, _handleMQTT) )
+            if action_topics and mqtt_topic.endswith( ZIGBEE2MQTT_ACTION_SUFFIX ):
+                # A switch listens on its '<device>/action' identifier; discovery
+                # subscribes to '<base>/#' and already receives the state topic.
+                listeners.append( await mqtt_subscribe(
+                    hass, mqtt_topic[:-len(ZIGBEE2MQTT_ACTION_SUFFIX)], _handleMQTT
+                ) )
             if blueprint.mqtt_sub_topics:
                 listeners.append( await mqtt_subscribe(hass, f"{mqtt_topic}/#", _handleMQTT) )
         except HomeAssistantError:


### PR DESCRIPTION
Follow-up to #77.

Zigbee2MQTT only republishes a button press to `zigbee2mqtt/<device>/action` when its Home Assistant integration is enabled (and `advanced.output` is `json`). Without that, the 79 Zigbee2MQTT blueprints written for `zigbee2mqtt/+/action` never match, even though the press is always part of the JSON on the device's state topic.

- For blueprints whose `mqtt_topic_format` ends in `/action`, a switch also subscribes to the state topic of its identifier and treats a non-empty string `action` in the JSON as if it had arrived on `/action` (`payload` = action, `topic` = `<device>/action`). Discovery already receives the state topic via `<base>/#` and goes through the same handler, so it finds the device either way.
- When Zigbee2MQTT publishes both, the copy that arrives on the other topic within 1 s is dropped. Retained state messages are ignored so a restart never replays the last press.
- Non-Zigbee2MQTT MQTT blueprints and `zigbee2mqtt/+` state-topic blueprints are untouched.
- README: troubleshooting and MQTT sections updated. Manifest bumped to 5.3.0.

Verified on the dev instance (HA 2026.9.0) with a temporary Moes TS0044 switch and a counting event action: state-only press → 1 run; state + `/action` within 80 ms (either order) → 1 run; `/action` only → 1 run; empty `action` and non-matching action → 0; two presses 1.2 s apart → 2; a retained state present when the switch subscribes → 0, a live press afterwards → 1; auto discovery via the state topic reports `zigbee2mqtt/<device>/action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4NaGiukVkz6M4tnjii9Mp
